### PR TITLE
Fixed variable typo for completions path.

### DIFF
--- a/functions/fundle.fish
+++ b/functions/fundle.fish
@@ -87,7 +87,7 @@ function __fundle_init -d "initialize fundle"
 		end
 
 		if begin; test -d $completions_dir; and not contains $completions_dir $fish_complete_path; end
-			set fish_complete_path $dir $fish_complete_path
+			set fish_complete_path $completions_dir $fish_complete_path
 		end
 
 		if test -f $init_file


### PR DESCRIPTION
Fixed the completions path variable name, I noticed this when my completions were not being loaded. I guess it was a copy/paste error.
