### PR TITLE
Provide path to plugin in repository

### DIFF
--- a/functions/fundle.fish
+++ b/functions/fundle.fish
@@ -199,7 +199,6 @@ function __fundle_load_plugin -a plugin -a path -a fundle_dir -a profile -d "loa
 	set -l init_file "$plugin_dir/init.fish"
 	set -l functions_dir "$plugin_dir/functions"
 	set -l completions_dir  "$plugin_dir/completions"
-	set -l plugins $__fundle_plugin_names
 	set -l plugin_paths $__fundle_plugin_name_paths
 
 	if begin; test -d $functions_dir; and not contains $functions_dir $fish_function_path; end

--- a/functions/fundle.fish
+++ b/functions/fundle.fish
@@ -322,9 +322,6 @@ function __fundle_plugin -d "add plugin to fundle" -a name
 	end
 end
 
-function __fundle_plugin_parse -d "parse plugin arguments"
-end
-
 function __fundle_version -d "prints fundle version"
 	echo $__fundle_current_version
 end

--- a/functions/fundle.fish
+++ b/functions/fundle.fish
@@ -167,12 +167,12 @@ function __fundle_show_doc_msg -d "show a link to fundle docs"
 	echo "See the docs for more info. https://github.com/tuvistavie/fundle"
 end
 
-function __fundle_load_plugin -a plugin -a fundle_dir -a profile -d "load a plugin"
+function __fundle_load_plugin -a plugin -a path -a fundle_dir -a profile -d "load a plugin"
 	if begin; set -q __fundle_loaded_plugins; and contains $plugin $__fundle_loaded_plugins; end
 		return 0
 	end
 
-	set -l plugin_dir "$fundle_dir/$plugin"
+	set -l plugin_dir (echo "$fundle_dir/$plugin/$path" | sed -e 's|/.$||')
 
 	if not test -d $plugin_dir
 		__fundle_show_doc_msg "$plugin not installed. You may need to run 'fundle install'"
@@ -184,6 +184,7 @@ function __fundle_load_plugin -a plugin -a fundle_dir -a profile -d "load a plug
 	set -l functions_dir "$plugin_dir/functions"
 	set -l completions_dir  "$plugin_dir/completions"
 	set -l plugins $__fundle_plugin_names
+	set -l plugin_paths $__fundle_plugin_name_paths
 
 	if begin; test -d $functions_dir; and not contains $functions_dir $fish_function_path; end
 		set fish_function_path $functions_dir $fish_function_path
@@ -204,14 +205,14 @@ function __fundle_load_plugin -a plugin -a fundle_dir -a profile -d "load a plug
 
 	set -g __fundle_loaded_plugins $plugin $__fundle_loaded_plugins
 
-	set -l dependencies (echo -s \n$plugins \n$__fundle_plugin_names | sed -e '/^$/d' | sort | uniq -u)
+	set -l dependencies (echo -s \n$plugin_paths \n$__fundle_plugin_name_paths | sed -e '/^$/d' | sort | uniq -u)
 	for dependency in $dependencies
-		__fundle_profile_or_run $profile __fundle_load_plugin $dependency $fundle_dir $profile
+		echo $dependency | sed -e 's/:/ /' | read -l -a name_path
+		__fundle_profile_or_run $profile __fundle_load_plugin $name_path[1] $name_path[2] $fundle_dir $profile
 	end
 
 	emit "init_$plugin_name" $plugin_dir
 end
-
 
 function __fundle_init -d "initialize fundle"
 	set -l fundle_dir (__fundle_plugins_dir)
@@ -228,8 +229,9 @@ Try reloading your shell if you just edited your configuration."
 		set profile 1
 	end
 
-	for plugin in $__fundle_plugin_names
-		__fundle_profile_or_run $profile __fundle_load_plugin $plugin $fundle_dir $profile
+	for name_path in $__fundle_plugin_name_paths
+		echo $name_path | sed -e 's/:/ /' | read -l -a name_path
+		__fundle_profile_or_run $profile __fundle_load_plugin $name_path[1] $name_path[2] $fundle_dir $profile
 	end
 end
 
@@ -254,7 +256,7 @@ end
 
 function __fundle_plugin -d "add plugin to fundle" -a name
 	set -l plugin_url ""
-	set -l plugin_path "/"
+	set -l plugin_path "."
 	set -l argv_count (count $argv)
 	if test $argv_count -eq 0
 		echo "usage: fundle plugin NAME [--url] URL [--path PATH]"
@@ -318,7 +320,7 @@ function __fundle_plugin -d "add plugin to fundle" -a name
 	if not contains $name $__fundle_plugin_names
 		set -g __fundle_plugin_names $__fundle_plugin_names $name
 		set -g __fundle_plugin_urls $__fundle_plugin_urls $plugin_url
-		set -g __fundle_plugin_paths $__fundle_plugin_paths $plugin_path
+		set -g __fundle_plugin_name_paths $__fundle_plugin_name_paths $name:$plugin_path
 	end
 end
 

--- a/functions/fundle.fish
+++ b/functions/fundle.fish
@@ -274,8 +274,8 @@ function __fundle_plugin -d "add plugin to fundle" -a name
 	set -l plugin_path "."
 	set -l argv_count (count $argv)
 	set -l skip_next true
-	if test $argv_count -eq 0
-		echo "usage: fundle plugin NAME [--url] URL [--path PATH]"
+	if test $argv_count -eq 0 -o -z "$argv"
+		echo "usage: fundle plugin NAME [[--url] URL] [--path PATH]"
 		return 1
 	else if test $argv_count -gt 1
 		set -l state "start"

--- a/test/__fundle_init_test.fish
+++ b/test/__fundle_init_test.fish
@@ -5,6 +5,7 @@ function -S setup
 	cp -r $DIRNAME/fixtures/foo $DIRNAME/fundle/foo
 	__fundle_plugin 'foo/with_dependency' # this should recursively load 'foo/with_init'
 	__fundle_plugin 'foo/without_init'
+	__fundle_plugin 'foo/subfolder' --path 'plugin'
 	set output (__fundle_init)
 	set code $status
 end
@@ -42,15 +43,17 @@ test "$TESTNAME loads all .fish files when init.fish not present"
 end
 
 test "$TESTNAME adds functions directory to fish_function_path"
-	"$DIRNAME/fundle/foo/with_init/functions" = $fish_function_path
+	"$DIRNAME/fundle/foo/with_init/functions" \
+	"$DIRNAME/fundle/foo/subfolder/plugin/functions" = $fish_function_path
 end
 
 test "$TESTNAME adds completions directory to fish_complete_path"
-	"$DIRNAME/fundle/foo/with_init/completions" = $fish_complete_path
+	"$DIRNAME/fundle/foo/with_init/completions" \
+	"$DIRNAME/fundle/foo/subfolder/plugin/completions" = $fish_complete_path
 end
 
 test "$TESTNAME loads plugin functions"
-	(functions -q my_plugin_function) 0 -eq $status
+	(functions -q my_plugin_function my_subfolder_plugin_function) 0 -eq $status
 end
 
 test "$TESTNAME with profile outputs profiling info"

--- a/test/__fundle_plugin_test.fish
+++ b/test/__fundle_plugin_test.fish
@@ -3,12 +3,12 @@ source $DIRNAME/helper.fish
 function -S setup
 	__fundle_cleanup_plugins
 	__fundle_plugin 'foo/bar'
-	__fundle_plugin 'foo/baz' '/path/to/baz'
-	__fundle_plugin 'foo/url-flag' --url '/path/to/url-flag'
+	__fundle_plugin 'foo/baz' '/url/for/baz'
+	__fundle_plugin 'foo/url-flag' --url '/url/for/url-flag'
 	__fundle_plugin 'foo/path-flag' --path 'path4'
-	__fundle_plugin 'foo/url-path-flag' '/path/to/url-flag' --path 'path5'
-	__fundle_plugin 'foo/url-flag-path-flag' --url '/path/to/url-flag' --path 'path6'
-	__fundle_plugin 'foo/path-flag-url-flag' --path 'path7' --url '/path/to/url-flag'
+	__fundle_plugin 'foo/url-path-flag' '/url/for/url-path-flag' --path 'path5'
+	__fundle_plugin 'foo/url-flag-path-flag' --url '/url/for/url-flag-path-flag' --path 'path6'
+	__fundle_plugin 'foo/path-flag-url-flag' --path 'path7' --url '/url/for/path-flag-url-flag'
 end
 
 test "$TESTNAME: adds plugins names"
@@ -29,19 +29,20 @@ end
 
 test "$TESTNAME: uses default url when not given"
 	(__fundle_get_url 'foo/bar'
-	 __fundle_get_url 'foo/path-flag') = (printf '%s\n' $__fundle_plugin_urls[1] $__fundle_plugin_urls[4])
+	 __fundle_get_url 'foo/path-flag') = $__fundle_plugin_urls[1] $__fundle_plugin_urls[4]
 end
 
 test "$TESTNAME: uses given url"
-	$__fundle_plugin_urls[2] \
-	$__fundle_plugin_urls[5] \
-	$__fundle_plugin_urls[6] \
-	$__fundle_plugin_urls[7] = (printf '%s\n' '/path/to/baz' '/path/to/url-flag' '/path/to/url-flag' '/path/to/url-flag')
+	'/url/for/baz' \
+	'/url/for/url-flag' \
+	'/url/for/url-path-flag' \
+	'/url/for/url-flag-path-flag' \
+	'/url/for/path-flag-url-flag' = $__fundle_plugin_urls[2..3] $__fundle_plugin_urls[5..7]
 end
 
 test "$TESTNAME: uses given path flag"
-	$__fundle_plugin_name_paths[4] \
-	$__fundle_plugin_name_paths[5] \
-	$__fundle_plugin_name_paths[6] \
-	$__fundle_plugin_name_paths[7] = (printf '%s\n' 'foo/path-flag:path4' 'foo/url-path-flag:path5' 'foo/url-flag-path-flag:path6' 'foo/path-flag-url-flag:path7')
+	'foo/path-flag:path4' \
+	'foo/url-path-flag:path5' \
+	'foo/url-flag-path-flag:path6' \
+	'foo/path-flag-url-flag:path7' = $__fundle_plugin_name_paths[4..7]
 end

--- a/test/__fundle_plugin_test.fish
+++ b/test/__fundle_plugin_test.fish
@@ -24,30 +24,30 @@ test "$TESTNAME: adds plugins paths"
 end
 
 test "$TESTNAME: adds names in order"
-	'foo/bar' = $__fundle_plugin_names[1] -a \
-	'foo/baz' = $__fundle_plugin_names[2] -a \
-	'foo/url-flag' = $__fundle_plugin_names[3] -a \
-	'foo/path-flag' = $__fundle_plugin_names[4] -a \
-	'foo/url-path-flag' = $__fundle_plugin_names[5] -a \
-	'foo/url-flag-path-flag' = $__fundle_plugin_names[6] -a \
-	'foo/path-flag-url-flag' = $__fundle_plugin_names[7]
+	$__fundle_plugin_names[1] \
+	$__fundle_plugin_names[2] \
+	$__fundle_plugin_names[3] \
+	$__fundle_plugin_names[4] \
+	$__fundle_plugin_names[5] \
+	$__fundle_plugin_names[6] \
+	$__fundle_plugin_names[7] = (printf '%s\n' 'foo/bar' 'foo/baz' 'foo/url-flag' 'foo/path-flag' 'foo/url-path-flag' 'foo/url-flag-path-flag' 'foo/path-flag-url-flag')
 end
 
 test "$TESTNAME: uses default url when not given"
-	(__fundle_get_url 'foo/bar') = $__fundle_plugin_urls[1] -a \
-	(__fundle_get_url 'foo/path-flag') = $__fundle_plugin_urls[4]
+	(__fundle_get_url 'foo/bar'
+	 __fundle_get_url 'foo/path-flag') = (printf '%s\n' $__fundle_plugin_urls[1] $__fundle_plugin_urls[4])
 end
 
 test "$TESTNAME: uses given url"
-	'/path/to/baz' = $__fundle_plugin_urls[2] -a \
-	'/path/to/url-flag' = $__fundle_plugin_urls[5] -a \
-	'/path/to/url-flag' = $__fundle_plugin_urls[6] -a \
-	'/path/to/url-flag' = $__fundle_plugin_urls[7]
+	$__fundle_plugin_urls[2] \
+	$__fundle_plugin_urls[5] \
+	$__fundle_plugin_urls[6] \
+	$__fundle_plugin_urls[7] = (printf '%s\n' '/path/to/baz' '/path/to/url-flag' '/path/to/url-flag' '/path/to/url-flag')
 end
 
 test "$TESTNAME: uses given path flag"
-	'foo/path-flag:path4' = $__fundle_plugin_name_paths[4] -a \
-	'foo/url-path-flag:path5' = $__fundle_plugin_name_paths[5] -a \
-	'foo/url-flag-path-flag:path6' = $__fundle_plugin_name_paths[6] -a \
-	'foo/path-flag-url-flag:path7' = $__fundle_plugin_name_paths[7]
+	$__fundle_plugin_name_paths[4] \
+	$__fundle_plugin_name_paths[5] \
+	$__fundle_plugin_name_paths[6] \
+	$__fundle_plugin_name_paths[7] = (printf '%s\n' 'foo/path-flag:path4' 'foo/url-path-flag:path5' 'foo/url-flag-path-flag:path6' 'foo/path-flag-url-flag:path7')
 end

--- a/test/__fundle_plugin_test.fish
+++ b/test/__fundle_plugin_test.fish
@@ -24,13 +24,7 @@ test "$TESTNAME: adds plugins paths"
 end
 
 test "$TESTNAME: adds names in order"
-	$__fundle_plugin_names[1] \
-	$__fundle_plugin_names[2] \
-	$__fundle_plugin_names[3] \
-	$__fundle_plugin_names[4] \
-	$__fundle_plugin_names[5] \
-	$__fundle_plugin_names[6] \
-	$__fundle_plugin_names[7] = (printf '%s\n' 'foo/bar' 'foo/baz' 'foo/url-flag' 'foo/path-flag' 'foo/url-path-flag' 'foo/url-flag-path-flag' 'foo/path-flag-url-flag')
+	'foo/bar foo/baz foo/url-flag foo/path-flag foo/url-path-flag foo/url-flag-path-flag foo/path-flag-url-flag' = "$__fundle_plugin_names"
 end
 
 test "$TESTNAME: uses default url when not given"

--- a/test/__fundle_plugin_test.fish
+++ b/test/__fundle_plugin_test.fish
@@ -4,24 +4,50 @@ function -S setup
 	__fundle_cleanup_plugins
 	__fundle_plugin 'foo/bar'
 	__fundle_plugin 'foo/baz' '/path/to/baz'
+	__fundle_plugin 'foo/url-flag' --url '/path/to/url-flag'
+	__fundle_plugin 'foo/path-flag' --path 'path4'
+	__fundle_plugin 'foo/url-path-flag' '/path/to/url-flag' --path 'path5'
+	__fundle_plugin 'foo/url-flag-path-flag' --url '/path/to/url-flag' --path 'path6'
+	__fundle_plugin 'foo/path-flag-url-flag' --path 'path7' --url '/path/to/url-flag'
 end
 
 test "$TESTNAME: adds plugins names"
-	2 -eq (count $__fundle_plugin_names)
+	7 -eq (count $__fundle_plugin_names)
 end
 
 test "$TESTNAME: adds plugins urls"
-	2 -eq (count $__fundle_plugin_urls)
+	7 -eq (count $__fundle_plugin_urls)
+end
+
+test "$TESTNAME: adds plugins paths"
+	7 -eq (count $__fundle_plugin_paths)
 end
 
 test "$TESTNAME: adds names in order"
-	'foo/bar' = $__fundle_plugin_names[1]
+	'foo/bar' = $__fundle_plugin_names[1] -a \
+	'foo/baz' = $__fundle_plugin_names[2] -a \
+	'foo/url-flag' = $__fundle_plugin_names[3] -a \
+	'foo/path-flag' = $__fundle_plugin_names[4] -a \
+	'foo/url-path-flag' = $__fundle_plugin_names[5] -a \
+	'foo/url-flag-path-flag' = $__fundle_plugin_names[6] -a \
+	'foo/path-flag-url-flag' = $__fundle_plugin_names[7]
 end
 
 test "$TESTNAME: uses default url when not given"
-	(__fundle_get_url 'foo/bar') = $__fundle_plugin_urls[1]
+	(__fundle_get_url 'foo/bar') = $__fundle_plugin_urls[1] -a \
+	(__fundle_get_url 'foo/path-flag') = $__fundle_plugin_urls[4]
 end
 
 test "$TESTNAME: uses given url"
-	'/path/to/baz' = $__fundle_plugin_urls[2]
+	'/path/to/baz' = $__fundle_plugin_urls[2] -a \
+	'/path/to/url-flag' = $__fundle_plugin_urls[5] -a \
+	'/path/to/url-flag' = $__fundle_plugin_urls[6] -a \
+	'/path/to/url-flag' = $__fundle_plugin_urls[7]
+end
+
+test "$TESTNAME: uses given path flag"
+	'path4' = $__fundle_plugin_paths[4] -a \
+	'path5' = $__fundle_plugin_paths[5] -a \
+	'path6' = $__fundle_plugin_paths[6] -a \
+	'path7' = $__fundle_plugin_paths[7]
 end

--- a/test/__fundle_plugin_test.fish
+++ b/test/__fundle_plugin_test.fish
@@ -20,7 +20,7 @@ test "$TESTNAME: adds plugins urls"
 end
 
 test "$TESTNAME: adds plugins paths"
-	7 -eq (count $__fundle_plugin_paths)
+	7 -eq (count $__fundle_plugin_name_paths)
 end
 
 test "$TESTNAME: adds names in order"
@@ -46,8 +46,8 @@ test "$TESTNAME: uses given url"
 end
 
 test "$TESTNAME: uses given path flag"
-	'path4' = $__fundle_plugin_paths[4] -a \
-	'path5' = $__fundle_plugin_paths[5] -a \
-	'path6' = $__fundle_plugin_paths[6] -a \
-	'path7' = $__fundle_plugin_paths[7]
+	'foo/path-flag:path4' = $__fundle_plugin_name_paths[4] -a \
+	'foo/url-path-flag:path5' = $__fundle_plugin_name_paths[5] -a \
+	'foo/url-flag-path-flag:path6' = $__fundle_plugin_name_paths[6] -a \
+	'foo/path-flag-url-flag:path7' = $__fundle_plugin_name_paths[7]
 end

--- a/test/fixtures/foo/subfolder/plugin/completions/my_subfolder_command.fish
+++ b/test/fixtures/foo/subfolder/plugin/completions/my_subfolder_command.fish
@@ -1,0 +1,1 @@
+complete -c my_subfolder_command -a foo -d "foo"

--- a/test/fixtures/foo/subfolder/plugin/functions/my_subfolder_plugin_function.fish
+++ b/test/fixtures/foo/subfolder/plugin/functions/my_subfolder_plugin_function.fish
@@ -1,0 +1,2 @@
+function my_subfolder_plugin_function
+end

--- a/test/helper.fish
+++ b/test/helper.fish
@@ -13,6 +13,7 @@ end
 function -S __fundle_cleanup_plugins
 	set -e __fundle_plugin_names
 	set -e __fundle_plugin_urls
+	set -e __fundle_plugin_paths
 	set -e __fundle_loaded_plugins
 	return 0
 end

--- a/test/helper.fish
+++ b/test/helper.fish
@@ -13,7 +13,7 @@ end
 function -S __fundle_cleanup_plugins
 	set -e __fundle_plugin_names
 	set -e __fundle_plugin_urls
-	set -e __fundle_plugin_paths
+	set -e __fundle_plugin_name_paths
 	set -e __fundle_loaded_plugins
 	return 0
 end


### PR DESCRIPTION
This pull request is based upon issue #11. It adds optional flag for URL and an optional argument `--path PATH` that specifies root of the plugin in repository to be loaded by fundle.

The usage of `fundle plugin` is now:

```
fundle plugin NAME [[--url] URL] [--path PATH]
```
