### PR TITLE
change verbs to match the ones of Vundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ yaourt -S fundle-git
 
 ### Updating
 
-From fundle 0.2.0 and onwards, you can use `fundle self-update` to update fundle.
+From fundle 0.2.0 and onwards, you can use `fundle upgrade` to upgrade fundle.
 
 ## Usage
 
@@ -114,20 +114,21 @@ for fundle to download them.
 You can also use
 
 ```
-fundle install -u
+fundle update
 ```
 
-to upgrade the plugins.
+to update the plugins.
 
 ## Commands
 
 * `fundle init`: Initialize fundle, loading all the available plugins
-* `fundle install [-u]`: Install (or update) all plugins
+* `fundle install`: Install all plugins
+* `fundle update`: Update all plugins
 * `fundle plugin PLUGIN [--url PLUGIN_URL] [--path PATH]`: Add a plugin to fundle.
   * `--url` set the URL to clone the plugin.
   * `--path` set the plugin path (relative to the repository root)
 * `fundle list [-s]`: List the currently installed plugins, including dependencies (-s gives a shorter version)
-* `fundle self-update`: Updates fundle to the latest version
+* `fundle upgrade`: Upgrades fundle to the latest version
 * `fundle version`: Displays the current version of fundle
 * `fundle help`: Displays available commands
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ yaourt -S fundle-git
 
 ### Updating
 
-From fundle 0.2.0 and onwards, you can use `fundle upgrade` to upgrade fundle.
+From fundle 0.2.0 and onwards, you can use `fundle self-update` to update fundle.
 
 ## Usage
 
@@ -123,12 +123,12 @@ to update the plugins.
 
 * `fundle init`: Initialize fundle, loading all the available plugins
 * `fundle install`: Install all plugins
-* `fundle update`: Update all plugins
+* `fundle update`: Update all plugins (deprecates: `fundle install -u`)
 * `fundle plugin PLUGIN [--url PLUGIN_URL] [--path PATH]`: Add a plugin to fundle.
   * `--url` set the URL to clone the plugin.
   * `--path` set the plugin path (relative to the repository root)
 * `fundle list [-s]`: List the currently installed plugins, including dependencies (-s gives a shorter version)
-* `fundle upgrade`: Upgrades fundle to the latest version
+* `fundle self-update`: Updates fundle to the latest version
 * `fundle version`: Displays the current version of fundle
 * `fundle help`: Displays available commands
 

--- a/completions/fundle.fish
+++ b/completions/fundle.fish
@@ -2,11 +2,10 @@ complete -f -c fundle -n '__fish_prog_needs_command' -a init -d "load all plugin
 complete -f -c fundle -n '__fish_prog_needs_command' -a plugin -d "add a plugin"
 complete -f -c fundle -n '__fish_prog_needs_command' -a list -d "list plugins"
 complete -f -c fundle -n '__fish_prog_needs_command' -a install -d "install all plugins"
-complete -f -c fundle -n '__fish_prog_needs_command' -a self-update -d "update fundle"
+complete -f -c fundle -n '__fish_prog_needs_command' -a upgrade -d "upgrade fundle"
+complete -f -c fundle -n '__fish_prog_needs_command' -a update -d "update existing plugins"
 complete -f -c fundle -n '__fish_prog_needs_command' -a version -d "display fundle version"
 complete -f -c fundle -n '__fish_prog_needs_command' -a help -d "display helps"
-
-complete -f -c fundle -n '__fish_prog_using_command install' -s u -l upgrade -d "upgrade existing plugins"
 
 complete -f -c fundle -n '__fish_prog_using_command list' -s s -l short -d "show a short list with plugin names only"
 

--- a/completions/fundle.fish
+++ b/completions/fundle.fish
@@ -2,10 +2,12 @@ complete -f -c fundle -n '__fish_prog_needs_command' -a init -d "load all plugin
 complete -f -c fundle -n '__fish_prog_needs_command' -a plugin -d "add a plugin"
 complete -f -c fundle -n '__fish_prog_needs_command' -a list -d "list plugins"
 complete -f -c fundle -n '__fish_prog_needs_command' -a install -d "install all plugins"
-complete -f -c fundle -n '__fish_prog_needs_command' -a upgrade -d "upgrade fundle"
 complete -f -c fundle -n '__fish_prog_needs_command' -a update -d "update existing plugins"
+complete -f -c fundle -n '__fish_prog_needs_command' -a self-update -d "update fundle"
 complete -f -c fundle -n '__fish_prog_needs_command' -a version -d "display fundle version"
 complete -f -c fundle -n '__fish_prog_needs_command' -a help -d "display helps"
+
+complete -f -c fundle -n '__fish_prog_using_command install' -s u -l update -d "update existing plugins (deprecated)"
 
 complete -f -c fundle -n '__fish_prog_using_command list' -s s -l short -d "show a short list with plugin names only"
 

--- a/functions/fundle.fish
+++ b/functions/fundle.fish
@@ -58,7 +58,7 @@ function __fundle_date -d "returns a date"
 	return 0
 end
 
-function __fundle_upgrade -d "upgrades fundle"
+function __fundle_self_update -d "updates fundle"
 	set -l fundle_repo_url "https://github.com/tuvistavie/fundle.git"
 	set -l latest (git ls-remote --tags $fundle_repo_url | sed -n -e 's|.*refs/tags/v\(.*\)|\1|p' | tail -n 1)
 	if test (__fundle_compare_versions $latest (__fundle_version)) != "gt"
@@ -135,33 +135,12 @@ function __fundle_get_url -d "returns the url for the given plugin" -a repo
 	echo "https://github.com/$repo.git"
 end
 
-function __fundle_install_plugin -d "install the given plugin" -a plugin -a git_url
-	if __fundle_no_git
-		return 1
-	end
-
-	set -l plugin_dir (__fundle_plugins_dir)/$plugin
-	set -l git_dir $plugin_dir/.git
-	set -l remote_url (__fundle_remote_url $git_url)
-
-	if test -d $plugin_dir
-		echo "$argv[1] installed in $plugin_dir"
-		return 0
-	else
-		echo "Installing $plugin"
-		git clone -q $remote_url $plugin_dir
-	end
-
-	set -l sha (__fundle_commit_sha $git_dir (__fundle_url_rev $git_url))
-	if test $status -eq 0
-		git --git-dir="$git_dir" --work-tree="$plugin_dir" checkout -q -f $sha
-	else
-		echo "Could not upgrade $plugin"
-		return 1
-	end
+function __fundle_update_plugin -d "update the given plugin" -a git_dir -a remote_url
+	git --git-dir=$git_dir remote set-url origin $remote_url ^ /dev/null; and \
+	git --git-dir=$git_dir fetch -q ^ /dev/null
 end
 
-function __fundle_update_plugin -d "updates the given plugin" -a plugin -a git_url
+function __fundle_install_plugin -d "install/update the given plugin" -a plugin -a git_url
 	if __fundle_no_git
 		return 1
 	end
@@ -169,11 +148,20 @@ function __fundle_update_plugin -d "updates the given plugin" -a plugin -a git_u
 	set -l plugin_dir (__fundle_plugins_dir)/$plugin
 	set -l git_dir $plugin_dir/.git
 	set -l remote_url (__fundle_remote_url $git_url)
+	set -l update ""
+
+	if contains __update $argv
+		set update true
+	end
 
 	if test -d $plugin_dir
-		echo "Upgrading $plugin"
-		git --git-dir=$git_dir remote set-url origin $remote_url ^ /dev/null; and \
-		git --git-dir=$git_dir fetch -q ^ /dev/null
+		if test -n "$update"
+			echo "Updating $plugin"
+			__fundle_update_plugin $git_dir $remote_url
+		else
+			echo "$argv[1] installed in $plugin_dir"
+			return 0
+		end
 	else
 		echo "Installing $plugin"
 		git clone -q $remote_url $plugin_dir
@@ -183,7 +171,7 @@ function __fundle_update_plugin -d "updates the given plugin" -a plugin -a git_u
 	if test $status -eq 0
 		git --git-dir="$git_dir" --work-tree="$plugin_dir" checkout -q -f $sha
 	else
-		echo "Could not upgrade $plugin"
+		echo "Could not update $plugin"
 		return 1
 	end
 end
@@ -267,21 +255,11 @@ function __fundle_install -d "install plugin"
 		__fundle_show_doc_msg "No plugin registered. You need to call 'fundle plugin NAME' before using 'fundle install'"
 	end
 
-	for i in (__fundle_seq (count $__fundle_plugin_names))
-		__fundle_install_plugin $__fundle_plugin_names[$i] $__fundle_plugin_urls[$i] $argv
+	if begin; contains -- -u $argv; or contains -- --upgrade $argv; end
+		echo "deprecation warning: please use 'fundle update' to update plugins"
+		set argv $argv __update
 	end
 
-	set -l original_plugins_count (count (__fundle_list -s))
-	__fundle_init
-
-	# if plugins count increase after init, new plugins have dependencies
-	# install new plugins dependencies if any
-	if test (count (__fundle_list -s)) -gt $original_plugins_count
-		__fundle_install $argv
-	end
-end
-
-function __fundle_update -d "update plugin"
 	for i in (__fundle_seq (count $__fundle_plugin_names))
 		__fundle_install_plugin $__fundle_plugin_names[$i] $__fundle_plugin_urls[$i] $argv
 	end
@@ -339,7 +317,7 @@ function __fundle_version -d "prints fundle version"
 end
 
 function __fundle_print_help -d "prints fundle help"
-	echo "usage: fundle (init | plugin | list | install | update | upgrade | version | help)"
+	echo "usage: fundle (init | plugin | list | install | update | self-update | version | help)"
 end
 
 function __fundle_list -d "list registered plugins"
@@ -382,9 +360,9 @@ function fundle -d "run fundle"
 		case "install"
 			__fundle_install $sub_args
 		case "update"
-			__fundle_update
-		case "upgrade"
-			__fundle_upgrade
+			__fundle_install __update $sub_args
+		case "self-update"
+			__fundle_self_update
 		case "version" -v --version
 			__fundle_version
 		case "help" -h --help


### PR DESCRIPTION
I would prefer to have the verbs to match the ones used by Vundle (I opened the issue #17), so I changed:

`fundle install -u` -> `fundle update`
`fundle self-update` -> `fundle upgrade`

This commit is just a draft of the changes, it should be refined for coding style.
