### PR TITLE
reload fundle.fish after self-update

### DIFF
--- a/functions/fundle.fish
+++ b/functions/fundle.fish
@@ -68,7 +68,7 @@ function __fundle_self_update -d "updates fundle"
 		set -l file_url (echo $file_url_template | sed -e "s/VERSION/v$latest/")
 		set -l tmp_file (mktemp /tmp/fundle.XXX)
 		set -l update_message "fundle has been updated to version $latest"
-		curl -Ls $file_url > $tmp_file; and mv $tmp_file (status -f); and echo $update_message; and return 0
+		curl -Ls $file_url > $tmp_file; and mv $tmp_file (status -f); and echo $update_message; and source (status -f); and return 0
 	end
 end
 


### PR DESCRIPTION
Since we are already bumping some version, it would be nice to re-source fundle.fish after a successful self-update. (I believe the commit is correct but I'm not sure since I didn't test it).
