### PR TITLE
Installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,14 @@ you can use the [tuvistavie/oh-my-fish-core](https://github.com/tuvistavie/oh-my
 
 ## Installation
 
-Just drop [fundle.fish](functions/fundle.fish) in your `~/.config/fish/functions` directory and you are done.
+You can use the installer:
+
+```sh
+curl -sfL https://git.io/fundle-install | fish
+```
+
+Or if you don't like to pipe to a shell, just drop [fundle.fish](functions/fundle.fish)
+in your `~/.config/fish/functions` directory and you are done.
 
 ```sh
 mkdir -p ~/.config/fish/functions
@@ -25,11 +32,7 @@ If you want to automatically install fundle when it is not present, you can add
 the following at the top of your `~/.config/fish/config.fish`.
 
 ```fish
-if not functions -q fundle
-    echo "[Downloading fundle ...]"
-    mkdir -p ~/.config/fish/functions
-    curl -#fL https://git.io/fundle > ~/.config/fish/functions/fundle.fish; and source ~/.config/fish/functions/fundle.fish
-end
+if not functions -q fundle; eval (curl -sfL https://git.io/fundle-install); end
 ```
 
 ### ArchLinux

--- a/install-fundle.fish
+++ b/install-fundle.fish
@@ -1,0 +1,4 @@
+echo "[Downloading fundle ...]";
+mkdir -p ~/.config/fish/functions;
+curl -#fL https://git.io/fundle > ~/.config/fish/functions/fundle.fish; and fish -c "fundle install"; and exec fish
+

--- a/install-fundle.fish
+++ b/install-fundle.fish
@@ -1,4 +1,4 @@
 echo "[Downloading fundle ...]";
 mkdir -p ~/.config/fish/functions;
-curl -#fL https://git.io/fundle > ~/.config/fish/functions/fundle.fish; and fish -c "fundle install"; and exec fish
-
+curl -#fL https://git.io/fundle > ~/.config/fish/functions/fundle.fish; and fish -c "fundle install"; and exec fish;
+# leave the semicolons at the end of the lines, they are needed by eval


### PR DESCRIPTION
I believe the installer is the preferred installation way (the same used for example by omf, fisherman), and simplifies what we need to put in the `config.fish` file.

The only missing part is to register `https://git.io/fundle-install` to link to the raw `install-fundle.fish` file created by this PR.
