### PR TITLE
avoid # in installer

### DIFF
--- a/install-fundle.fish
+++ b/install-fundle.fish
@@ -1,4 +1,4 @@
 echo "[Downloading fundle ...]";
 mkdir -p ~/.config/fish/functions;
-curl -#fL https://git.io/fundle > ~/.config/fish/functions/fundle.fish; and fish -c "fundle install"; and exec fish;
+curl -sfL https://git.io/fundle > ~/.config/fish/functions/fundle.fish; and fish -c "fundle install"; and exec fish;
 # leave the semicolons at the end of the lines, they are needed by eval


### PR DESCRIPTION
`-#` is not liked by some environments
