### PR TITLE
Add support for XDG Base Directory environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-FISHTAPE = $(HOME)/.config/fish/functions/fishtape.fish
+export XDG_CONFIG_HOME ?= $(HOME)/.config
+
+FISHTAPE = $(XDG_CONFIG_HOME)/fish/functions/fishtape.fish
 
 test: $(FISHTAPE)
 	fish -c 'fishtape test/*_test.fish'

--- a/functions/fundle.fish
+++ b/functions/fundle.fish
@@ -106,7 +106,11 @@ end
 
 function __fundle_plugins_dir -d "returns fundle directory"
 	if test -z "$fundle_plugins_dir"
-		echo $HOME/.config/fish/fundle
+		if test -n "$XDG_CONFIG_HOME"
+			echo $XDG_CONFIG_HOME/fish/fundle
+		else
+			echo $HOME/.config/fish/fundle
+		end
 	else
 		echo $fundle_plugins_dir
 	end

--- a/install-fishtape.sh
+++ b/install-fishtape.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-
-mkdir -p ~/.config/fish/functions
-curl -L https://raw.githubusercontent.com/fisherman/fishtape/master/fishtape.fish > ~/.config/fish/functions/fishtape.fish
+[ -z "$XDG_CONFIG_HOME" ] && XDG_CONFIG_HOME="~/.config"
+mkdir -p $XDG_CONFIG_HOME/fish/functions
+curl -L https://raw.githubusercontent.com/fisherman/fishtape/master/fishtape.fish > $XDG_CONFIG_HOME/fish/functions/fishtape.fish

--- a/install-fundle.fish
+++ b/install-fundle.fish
@@ -1,4 +1,5 @@
 echo "[Downloading fundle ...]";
-mkdir -p ~/.config/fish/functions;
-curl -sfL https://git.io/fundle > ~/.config/fish/functions/fundle.fish; and fish -c "fundle install"; and exec fish;
+test -z "$XDG_CONFIG_HOME"; and set XDG_CONFIG_HOME ~/.config;
+mkdir -p $XDG_CONFIG_HOME/fish/functions;
+curl -sfL https://git.io/fundle > $XDG_CONFIG_HOME/fish/functions/fundle.fish; and fish -c "fundle install"; and exec fish;
 # leave the semicolons at the end of the lines, they are needed by eval

--- a/test/utils_test.fish
+++ b/test/utils_test.fish
@@ -6,7 +6,7 @@ function -S setup
 end
 
 test "__fundle_plugins_dir: returns a default value when fundle_plugins_dir is not set"
-	"$HOME/.config/fish/fundle" = (set -e fundle_plugins_dir; __fundle_plugins_dir)
+	"$XDG_CONFIG_HOME/fish/fundle" = (set -e fundle_plugins_dir; __fundle_plugins_dir)
 end
 test "__fundle_plugins_dir: returns fundle_plugins_dir when set"
 	"$DIRNAME/fundle" = (set -g fundle_plugins_dir $DIRNAME/fundle; and __fundle_plugins_dir)


### PR DESCRIPTION
Fish follows the XDG Base Directory specifications, resulting in errors when the `XDG_CONFIG_HOME` variable is set to something else than `~/.config`.

This pull request changes everything necessary to support the environment variables, but `README.md` has not been updated.