### PR TITLE
Improve performance

### DIFF
--- a/functions/fundle.fish
+++ b/functions/fundle.fish
@@ -34,21 +34,6 @@ function __fundle_compare_versions -a version1 -a version2
 	echo -n "eq"; and return 0
 end
 
-function __fundle_profile -d "runs a function in profile mode"
-	set -l start_time (__fundle_date +%s%N)
-	eval $argv
-	set -l ellapsed_time (math \((__fundle_date +%s%N) - $start_time\) / 1000)
-	echo "$argv": {$ellapsed_time}us
-end
-
-function __fundle_profile_or_run -a profile
-	if test $profile -eq 1
-		__fundle_profile $argv[2..-1]
-	else
-		eval $argv[2..-1]
-	end
-end
-
 function __fundle_date -d "returns a date"
 	set -l d (date +%s%N)
 	if echo $d | string match -rvq 'N'
@@ -242,7 +227,14 @@ function __fundle_load_plugin -a plugin -a path -a fundle_dir -a profile -d "loa
 	set -l dependencies (printf '%s\n' $plugin_paths $__fundle_plugin_name_paths | sort | uniq -u)
 	for dependency in $dependencies
         set -l name_path (string split : -- $dependency)
-		__fundle_profile_or_run $profile __fundle_load_plugin $name_path[1] $name_path[2] $fundle_dir $profile
+        if test "$profile" -eq 1
+	        set -l start_time (__fundle_date +%s%N)
+		    __fundle_load_plugin $name_path[1] $name_path[2] $fundle_dir $profile
+	        set -l ellapsed_time (math \((__fundle_date +%s%N) - $start_time\) / 1000)
+	        echo "$argv": {$ellapsed_time}us
+        else
+		    __fundle_load_plugin $name_path[1] $name_path[2] $fundle_dir $profile
+        end
 	end
 
 	emit "init_$plugin_name" $plugin_dir
@@ -280,7 +272,14 @@ Try reloading your shell if you just edited your configuration."
 
 	for name_path in $__fundle_plugin_name_paths
         set -l name_path (string split : -- $name_path)
-		__fundle_profile_or_run $profile __fundle_load_plugin $name_path[1] $name_path[2] $fundle_dir $profile
+        if test "$profile" -eq 1
+	        set -l start_time (__fundle_date +%s%N)
+		    __fundle_load_plugin $name_path[1] $name_path[2] $fundle_dir $profile
+	        set -l ellapsed_time (math \((__fundle_date +%s%N) - $start_time\) / 1000)
+	        echo "$argv": {$ellapsed_time}us
+        else
+		    __fundle_load_plugin $name_path[1] $name_path[2] $fundle_dir $profile
+        end
 	end
 
 	__fundle_bind

--- a/functions/fundle.fish
+++ b/functions/fundle.fish
@@ -21,16 +21,15 @@ function __fundle_next_arg -a index
 end
 
 function __fundle_compare_versions -a version1 -a version2
-    set -l v1 (string split . -- $version1 | string replace -ra '[a-z]+' '')
-    set -l v2 (string split . -- $version2 | string replace -ra '[a-z]+' '')
-    for i in 1 2 3 4
-        if test \( -n "$v1[$i]" -a -z "$v2[$i]" \) -o \( -n "$v1[$i]" -a -n "$v2[$i]" -a "$v1[$i]" -gt "$v2[$i]" \)
-            echo -n lt; and return 0
-		else if test \( -z "$v1[$i]" -a -n "$v2[$i]" \) -o \( -n "$v1[$i]" -a -n "$v2[$i]" -a "$v1[$i]" -gt "$v2[$i]" \)
+	for i in (__fundle_seq 4)
+		set -l v1 (echo $version1 | cut -d '.' -f $i | sed -Ee 's/[a-z]+//g')
+		set -l v2 (echo $version2 | cut -d '.' -f $i | sed -Ee 's/[a-z]+//g')
+		if test \( -n $v1 -a -z $v2 \) -o \( -n $v1 -a -n $v2 -a $v1 -lt $v2 \)
+			echo -n "lt"; and return 0
+		else if test \( -z $v1 -a -n $v2 \) -o \( -n $v1 -a -n $v2 -a $v1 -gt $v2 \)
 			echo -n "gt"; and return 0
 		end
-    end
-
+	end
 	echo -n "eq"; and return 0
 end
 

--- a/functions/fundle.fish
+++ b/functions/fundle.fish
@@ -193,14 +193,15 @@ function __fundle_load_plugin -a plugin -a path -a fundle_dir -a profile -d "loa
 		return 0
 	end
 
-	set -l plugin_dir (echo "$fundle_dir/$plugin/$path" | sed -e 's|/.$||')
+	set -l plugin_dir (string replace -r '/.$' '' -- "$fundle_dir/$plugin/$path")
 
 	if not test -d $plugin_dir
 		__fundle_show_doc_msg "$plugin not installed. You may need to run 'fundle install'"
 		return 0
 	end
 
-	set -l plugin_name (echo $plugin | awk -F/ '{print $NF}' | sed -e s/plugin-//)
+    # Take everything but "plugin-" from the last path component
+    set -l plugin_name (string replace -r '.*/(plugin-)?(.*)$' '$2' -- $plugin)
 	set -l init_file "$plugin_dir/init.fish"
 	set -l conf_dir "$plugin_dir/conf.d"
 	set -l bindings_file  "$plugin_dir/key_bindings.fish"
@@ -238,7 +239,7 @@ function __fundle_load_plugin -a plugin -a path -a fundle_dir -a profile -d "loa
 
 	set -l dependencies (echo -s \n$plugin_paths \n$__fundle_plugin_name_paths | sed -e '/^$/d' | sort | uniq -u)
 	for dependency in $dependencies
-		echo $dependency | sed -e 's/:/ /' | read -l -a name_path
+        set -l name_path (string split : -- $dependency)
 		__fundle_profile_or_run $profile __fundle_load_plugin $name_path[1] $name_path[2] $fundle_dir $profile
 	end
 

--- a/functions/fundle.fish
+++ b/functions/fundle.fish
@@ -221,12 +221,12 @@ function __fundle_load_plugin -a plugin -a path -a fundle_dir -a profile -d "loa
 		source $init_file
 	else if test -d $conf_dir
 		# read all *.fish files in conf.d
-		for f in (find $conf_dir -maxdepth 1 -iname "*.fish")
+		for f in $conf_dir/*.fish
 			source $f
 		end
 	else
 		# read all *.fish files if no init.fish or conf.d found
-		for f in (find $plugin_dir -maxdepth 1 -iname "*.fish")
+		for f in $plugin_dir/*.fish
 			source $f
 		end
 	end
@@ -311,7 +311,7 @@ end
 function __fundle_clean -d "cleans fundle directory"
 	set -l fundle_dir (__fundle_plugins_dir)
 	set -l used_plugins (__fundle_list -s)
-	set -l installed_plugins (find $fundle_dir -mindepth 2 -maxdepth 2 -type d)
+    set -l installed_plugins $fundle_dir/*/*/
 	for installed_plugin in $installed_plugins
 		set -l plugin (echo $installed_plugin | sed -e "s|$fundle_dir/||")
 		if not contains $plugin $used_plugins

--- a/functions/fundle.fish
+++ b/functions/fundle.fish
@@ -50,7 +50,7 @@ end
 
 function __fundle_date -d "returns a date"
 	set -l d (date +%s%N)
-	if echo $d | grep -v 'N' > /dev/null 2>&1
+	if echo $d | string match -rvq 'N'
 		echo $d
 	else
 		gdate +%s%N
@@ -126,7 +126,7 @@ function __fundle_no_git -d "check if git is installed"
 end
 
 function __fundle_check_date -d "check date"
-	if date +%s%N | grep -v 'N' > /dev/null 2>&1
+	if date +%s%N | string match -rvq 'N'
 		return 0
 	end
 	if command -s gdate > /dev/null 2>&1

--- a/functions/fundle.fish
+++ b/functions/fundle.fish
@@ -239,7 +239,7 @@ function __fundle_load_plugin -a plugin -a path -a fundle_dir -a profile -d "loa
 
 	set -g __fundle_loaded_plugins $plugin $__fundle_loaded_plugins
 
-	set -l dependencies (echo -s \n$plugin_paths \n$__fundle_plugin_name_paths | sed -e '/^$/d' | sort | uniq -u)
+	set -l dependencies (printf '%s\n' $plugin_paths $__fundle_plugin_name_paths | sort | uniq -u)
 	for dependency in $dependencies
         set -l name_path (string split : -- $dependency)
 		__fundle_profile_or_run $profile __fundle_load_plugin $name_path[1] $name_path[2] $fundle_dir $profile

--- a/functions/fundle.fish
+++ b/functions/fundle.fish
@@ -117,7 +117,8 @@ function __fundle_plugins_dir -d "returns fundle directory"
 end
 
 function __fundle_no_git -d "check if git is installed"
-	if not which git > /dev/null 2>&1
+    # `command -q` is >= 2.5.0
+	if not command -s git > /dev/null 2>&1
 		echo "git needs to be installed and in the path"
 		return 0
 	end
@@ -128,7 +129,7 @@ function __fundle_check_date -d "check date"
 	if date +%s%N | grep -v 'N' > /dev/null 2>&1
 		return 0
 	end
-	if which gdate > /dev/null 2>&1
+	if command -s gdate > /dev/null 2>&1
 		return 0
 	end
 	echo "You need to have a GNU date compliant date installed to use profiling. Use 'brew install coreutils' on OSX"

--- a/functions/fundle.fish
+++ b/functions/fundle.fish
@@ -21,15 +21,16 @@ function __fundle_next_arg -a index
 end
 
 function __fundle_compare_versions -a version1 -a version2
-	for i in (__fundle_seq 4)
-		set -l v1 (echo $version1 | cut -d '.' -f $i | sed -Ee 's/[a-z]+//g')
-		set -l v2 (echo $version2 | cut -d '.' -f $i | sed -Ee 's/[a-z]+//g')
-		if test \( -n $v1 -a -z $v2 \) -o \( -n $v1 -a -n $v2 -a $v1 -lt $v2 \)
-			echo -n "lt"; and return 0
-		else if test \( -z $v1 -a -n $v2 \) -o \( -n $v1 -a -n $v2 -a $v1 -gt $v2 \)
+    set -l v1 (string split . -- $version1 | string replace -ra '[a-z]+' '')
+    set -l v2 (string split . -- $version2 | string replace -ra '[a-z]+' '')
+    for i in 1 2 3 4
+        if test \( -n "$v1[$i]" -a -z "$v2[$i]" \) -o \( -n "$v1[$i]" -a -n "$v2[$i]" -a "$v1[$i]" -gt "$v2[$i]" \)
+            echo -n lt; and return 0
+		else if test \( -z "$v1[$i]" -a -n "$v2[$i]" \) -o \( -n "$v1[$i]" -a -n "$v2[$i]" -a "$v1[$i]" -gt "$v2[$i]" \)
 			echo -n "gt"; and return 0
 		end
-	end
+    end
+
 	echo -n "eq"; and return 0
 end
 


### PR DESCRIPTION
This successively improves `fundle init` time for 19 plugins from ~330ms to ~75ms, mainly by replacing use of external tools with `string` (which requires fish >= 2.3.0 from 2016).

Most of these commits are fairly self-explanatory.

I've only lightly tested this as I don't use fundle myself. The commits that I'd assume require the most testing are 9479053 and b488003.

Also, removing `eval` is a good in itself and in this case might even fix a few latent bugs.

Fixes #38.

Closes #25 (absolutely no compatibility with <2.3 anymore, but it's been a few years since that issue was opened).