### PR TITLE
BREAKING CHANGE: Match oh-my-fish compatibility behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,9 @@ A plugin basically has the following structure.
 * `completions` is the directory containing the plugin completions. This directory will
   be added to `fish_complete_path`.
 
-NOTE: if no `init.fish` file is found, all the files with a `.fish` extensions in the
-top directory of the plugin will be loaded. This is to make the plugins compatible with
-[oh-my-fish plugins](https://github.com/oh-my-fish).
+NOTE: if no `init.fish` file is found, the root folder of the plugin is treated
+as a functions directory. This is to make the plugins compatible with
+[oh-my-fish plugins](https://github.com/oh-my-fish) themes.
 
 ## Managing dependencies
 

--- a/functions/fundle.fish
+++ b/functions/fundle.fish
@@ -196,11 +196,11 @@ function __fundle_load_plugin -a plugin -a path -a fundle_dir -a profile -d "loa
 	set -l plugin_paths $__fundle_plugin_name_paths
 
 	if begin; test -d $functions_dir; and not contains $functions_dir $fish_function_path; end
-		set fish_function_path $functions_dir $fish_function_path
+		set fish_function_path $fish_function_path[1] $functions_dir $fish_function_path[2..-1]
 	end
 
 	if begin; test -d $completions_dir; and not contains $completions_dir $fish_complete_path; end
-		set fish_complete_path $completions_dir $fish_complete_path
+		set fish_complete_path $fish_complete_path[1] $completions_dir $fish_complete_path[2..-1]
 	end
 
 	if test -f $init_file

--- a/functions/fundle.fish
+++ b/functions/fundle.fish
@@ -211,10 +211,12 @@ function __fundle_load_plugin -a plugin -a path -a fundle_dir -a profile -d "loa
 			source $f
 		end
 	else
-		# read all *.fish files if no init.fish or conf.d found
-		for f in $plugin_dir/*.fish
-			source $f
-		end
+	    # For compatibility with oh-my-fish themes, if there is no `init.fish` file in the plugin,
+	    # which is the case with themses, the root directory of the plugin is trerated as a functions
+	    # folder, so we include it in the `fish_function_path` variable.
+	    if not contains $plugin_dir $fish_function_path
+		    set fish_function_path $fish_function_path[1] $plugin_dir $fish_function_path[2..-1]
+	    end
 	end
 
 	if test -f $bindings_file

--- a/test/__fundle_init_test.fish
+++ b/test/__fundle_init_test.fish
@@ -38,8 +38,8 @@ test "$TESTNAME: does not load other .fish files when init.fish present"
 	-z "$i_should_be_empty"
 end
 
-test "$TESTNAME loads all .fish files when init.fish not present"
-	-n "$i_do_have_init_file"
+test "$TESTNAME treats package as function folder when init.fish not present"
+	-n (no_init)
 end
 
 test "$TESTNAME adds functions directory to fish_function_path"

--- a/test/fixtures/foo/without_init/no_init.fish
+++ b/test/fixtures/foo/without_init/no_init.fish
@@ -1,1 +1,3 @@
-set -g i_do_have_init_file 'not empty'
+function no_init
+    echo "not_empty"
+end

--- a/test/fundle_test.fish
+++ b/test/fundle_test.fish
@@ -17,5 +17,5 @@ test "$TESTNAME init: loads registered plugin"
 		and cp -r $path/fixtures/foo/without_init $path/fundle/foo/without_init;
 		and fundle plugin 'foo/without_init';
 		and fundle init;
-		and echo "$i_do_have_init_file")
+		and no_init)
 end


### PR DESCRIPTION
This pull request does:

- Preserve user defined functions and completions with higher precedence during
Fundle initialization

- Changes the no `init.fish` fallback behaviour to use the root folder as a
functions folder rather than sourcing `*.fish`

- Fixes tests due to breaking change


After reading about [a bug in theme-bobthefish][1] regarding fundle, I realized
it happened because of two things:

1. Fundle was sourcing all the files in the root folder of theme-bobthefish,
treating the function definitions as literal shell commands. Because of this,
they always had higher precedence over functions defined in the files folder.

2. Fundle was prepending all the packages' function folders in the
`fish_function_path`, such that plugin functions had higher precedence. This
wouldn't allow an overridden user function to be correctly found by fish.

After inspecting the oh-my-fish source code, I concluded the behaviour addressed
the current no `init.fish` appears not to be correct, because of:

1. [oh-my-fish **only** sources `init.fish` files and `conf.d` folders inside packages][2]
2. [oh-my-fish **includes** theme root folders in the fish_function_path variable][3].

Because the README of fundle said the current fallback behaviour for no `init.fish` file
of sourcing `*.fish` in the root directory was due to preserve compatibility with
oh-my-fish plugins, and that is apparantly not oh-my-fish's actual behaviour, I figured
it was supposed to be different, hence this pull request.

[1]: https://github.com/oh-my-fish/theme-bobthefish/issues/136
[2]: https://github.com/oh-my-fish/oh-my-fish/blob/master/lib/require.fish#L75
[3]: https://github.com/oh-my-fish/oh-my-fish/blob/master/init.fish#L16