### PR TITLE
Update single plugin

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,8 +1,0 @@
-##########################################################
-####    WhiteSource Integration configuration file    ####
-##########################################################
-
-# Configuration #
-#---------------#
-ws.repo.scan=true
-vulnerable.check.run.conclusion.level=failure

--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,8 @@
+##########################################################
+####    WhiteSource Integration configuration file    ####
+##########################################################
+
+# Configuration #
+#---------------#
+ws.repo.scan=true
+vulnerable.check.run.conclusion.level=failure

--- a/functions/fundle.fish
+++ b/functions/fundle.fish
@@ -159,13 +159,12 @@ function __fundle_install_plugin -d "install the given plugin" -a plugin -a git_
 end
 
 function __fundle_update -d "update the given plugin, or all if unspecified" -a plugin
-  if set -q plugin
-    if test ! -d (__fundle_plugins_dir)/$plugin/.git;
-      echo "$plugin not installed. You may need to run 'fundle install'"
-      set -e plugin
-    end
+  if test -n "$plugin"
+    test ! -d (__fundle_plugins_dir)/$plugin/.git;
+      and echo "$plugin not installed. You may need to run 'fundle install'";
+      and set -e plugin
   end
-  if set -q plugin
+  if test -n "$plugin"
     echo "Updating $plugin"
     set -l git_dir (__fundle_plugins_dir)/$plugin/.git
     __fundle_update_plugin $git_dir (__fundle_remote_url $git_url)


### PR DESCRIPTION
My fork implements a fairly simple modification to [functions/fundle.fish](https://github.com/danhper/fundle/blob/master/functions/fundle.fish).

Running `fundle update $plugin` with `$plugin` one of the names in `fundle list --short` will pull down only that plugin; running `fundle update $plugin` with `$plugin` **NOT** one of the names in `fundle list --short` will display an error message and pull down the full list; running `fundle update` will pull down the full list as normal.

This way, users may specify (or randomize) the order in which plugins are updated, or make sure a plugin does _not_ get updated, i.e. one that is not available online.