### PR TITLE
feat: Add support for @<tag> in plugin name

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,19 @@ fundle plugin 'danhper/fish-fastdir'
 
 will install the repository at https://github.com/danhper/fish-fastdir.
 
+To pick a specific version of the plugins, you can append @ followed by a tag from the repo:
+```
+fundle plugin 'joseluisq/gitnow@2.7.0'
+```
+will install Gitnow release 2.7.0 at https://github.com/joseluisq/gitnow/releases/tag/2.7.0.
+
 If you need to change the repository, you can pass it with `--url` and
 it will be passed directly to `git clone`:
 
 ```
 fundle plugin 'danhper/fish-fastdir' --url 'git@github.com:danhper/fish-fastdir.git'
 ```
+Keep in mind that this option overrides any tag set with '@'.
 
 It also works with other repository hosts:
 

--- a/functions/fundle.fish
+++ b/functions/fundle.fish
@@ -123,7 +123,13 @@ function __fundle_check_date -d "check date"
 end
 
 function __fundle_get_url -d "returns the url for the given plugin" -a repo
-	echo "https://github.com/$repo.git"
+    set split (string split @ $repo)
+    set repo $split[1]
+    set tag  $split[2]
+    set url "https://github.com/$repo.git"
+
+    test ! -z "$tag"; and set url (string join "#tags/" "$url" "$tag")
+    echo "$url"
 end
 
 
@@ -380,6 +386,7 @@ function __fundle_plugin -d "add plugin to fundle" -a name
 		end
 	end
 	test -z "$plugin_url"; and set plugin_url (__fundle_get_url $name)
+    set name (string split @ $name)[1]
 
 	if not contains $name $__fundle_plugin_names
 		set -g __fundle_plugin_names $__fundle_plugin_names $name


### PR DESCRIPTION
Choosing a specific release of a plugin should be done in a user
friendly way. Therefore, it should be as simple as adding a tag
at the end of the plugin name consisting of username/repository.
This small modifications makes this possible using '@' as a delimiter.

Example:
    `fundle plugin 'joseluisq/gitnow@2.7.0'`

Not selecting a tag still acts the same as usual.