### PR TITLE
feat: Make `__fundle_init` return 1 when a plugin is not installed

### DIFF
--- a/functions/fundle.fish
+++ b/functions/fundle.fish
@@ -220,7 +220,7 @@ function __fundle_load_plugin -a plugin -a path -a fundle_dir -a profile -d "loa
 
 	if not test -d $plugin_dir
 		__fundle_show_doc_msg "$plugin not installed. You may need to run 'fundle install'"
-		return 0
+		return 1
 	end
 
     # Take everything but "plugin-" from the last path component
@@ -308,6 +308,7 @@ Try reloading your shell if you just edited your configuration."
 		set profile 1
 	end
 
+    set -l has_uninstalled_plugins 0
 	for name_path in $__fundle_plugin_name_paths
         set -l name_path (string split : -- $name_path)
         if test "$profile" -eq 1
@@ -316,11 +317,12 @@ Try reloading your shell if you just edited your configuration."
 	        set -l ellapsed_time (math \((__fundle_date +%s%N) - $start_time\) / 1000)
 	        echo "$name_path[1]": {$ellapsed_time}us
         else
-		    __fundle_load_plugin $name_path[1] $name_path[2] $fundle_dir $profile
+		    __fundle_load_plugin $name_path[1] $name_path[2] $fundle_dir $profile || set has_uninstalled_plugins 1
         end
 	end
 
 	__fundle_bind
+    return $has_uninstalled_plugins
 end
 
 function __fundle_install -d "install plugin"


### PR DESCRIPTION
After a quick look through `fundle.fish`, I noticed that `__fundle_init`'s return value isn't used anywhere.
In a way, it makes sens because it is not a function that fundle itself relies on the output of to determine anything.
For a user, though, this makes scripting the installation of plugins slightly more tedious.

This PR changes that.
It's a very simple change, but still a great quality of life improvement IMO.

As for a concrete, real-life example, my plugin initialisation file contains this:
(Skip to the last `if` statement if you only want to see the change brought by this PR)
```fish
# Automatically install fundle
if not functions -q fundle;
    eval (curl -sfL https://git.io/fundle-install);
end

# Easily access your plugin folder
set -Ux fish_plugin_dir (realpath $__fish_config_dir/fundle)
# And plugin list
set -Ux fish_plugins (realpath $__fish_config_dir/fish_plugins)

# Create the directory if necessary
if ! test -d $fish_plugin_dir
  mkdir -p $fish_plugin_dir
end

# Read the plugin list and store it
set -l __plugins (
  string split0 -- (
    # Filter out commented lines
    string match -r '^\s*[^#].+$' -- (cat $fish_plugins)
  )
)

# Enable found plugins
for p in $__plugins
  fundle plugin $p
end

# Try initialising plugins.
# If any are missing, fundle will output a message, and stay silent otherwise.
# This is what we test to determine if we need to run the install command.
if string match -qr 'not installed' -- (string collect -- (fundle init))
    set_color brgreen
      echo "Populating your plugin directory ($fish_plugin_dir)..."
    set_color normal
      fundle install | string match -er 'Installing'
    set_color brgreen
      echo "Done !"
    set_color normal
    exec fish
end
```
Note how the last `if`'s test is clearly suboptimal, whereas when `__fundle_init` returns `1` on uninstalled plugins, you could change it to
```fish
# Try initialising plugins.
# If any are missing, install them and reload the shell.
if not fundle init >/dev/null
    # ...
end
```