### PR TITLE
fix: Set __fundle_current_version to the correct patch

### DIFF
--- a/functions/fundle.fish
+++ b/functions/fundle.fish
@@ -1,4 +1,4 @@
-set __fundle_current_version '0.7.0'
+set __fundle_current_version '0.7.1'
 
 function __fundle_seq -a upto
 	seq 1 1 $upto 2>/dev/null


### PR DESCRIPTION
Current version number in `fundle.fish` from the `master` branch doesn't reflect the actual latest release tag on the remote.
This made `fundle self-update` download the same file again any time it was called.